### PR TITLE
Prevent type error in registerStore

### DIFF
--- a/lib/PgSubscription.js
+++ b/lib/PgSubscription.js
@@ -64,6 +64,11 @@ var registerStore = function(connection, name){
       var subBuffer = _.filter(buffer, function(sub){
         return sub.subscriptionId === msg.id;
       })[0];
+
+      if (!subBuffer){
+        return;
+      }
+
       var sub = subBuffer.instance;
 
       if(msg.msg === 'added' &&

--- a/test/PgSubscription.js
+++ b/test/PgSubscription.js
@@ -298,6 +298,16 @@ function(test, done){
 
     Meteor.setTimeout(function() {
       test.equal(players.length, expectedRows.length);
+
+      // Test multiple quick changes to subscription
+      for (var i = 0; i < expectedRows.length; i++) {
+        players.change(i);
+      }
+      players.change();
+
+      Meteor.setTimeout(function() {
+        test.equal(player.length, expectedRows.length);
+      }, POLL_WAIT);
       done();
     }, POLL_WAIT);
   }, POLL_WAIT);


### PR DESCRIPTION
This should fix

    [TypeError: Cannot read property 'instance' of undefined]

in the `registerStore` function.

The added tinytest needs to fail on that type error though. It is currently only visible on the console running the test and won't fail the actual scenario.