### PR TITLE
Test for quickly changing a PgSubscription

### DIFF
--- a/test/PgSubscription.js
+++ b/test/PgSubscription.js
@@ -302,3 +302,15 @@ function(test, done){
     }, POLL_WAIT);
   }, POLL_WAIT);
 });
+
+Tinytest.addAsync(SUITE_PREFIX + 'Quick Change',
+function(test, done){
+  for (var i = 0; i < expectedRows.length; i++) {
+    players.change(i);
+  }
+  players.change();
+  Meteor.setTimeout(function () {
+    test.equal(players.length, expectedRows.length);
+    done();
+  }, POLL_WAIT);
+});


### PR DESCRIPTION
I've created a separate test for that error.

This test should raise the

```
[TypeError: Cannot read property 'instance' of undefined]
```

in the `registerStore` function.

The added tinytest **still** needs to fail on that type error though. It is currently **only** visible on the console running the test and **won't fail the actual scenario**.
